### PR TITLE
Add Tavily name resolution for abbreviated author names and TSV support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,12 @@ All source code lives in `openalex_tool_pkg/`. The installed package entry point
 - **`openalex_tool_pkg/openalex_client.py`** — All OpenAlex API interaction. Handles pagination, request batching (max 25 author IDs per request due to URL length limits), deduplication, rate limiting (exponential backoff + Retry-After), and "polite pool" access via email parameter.
 - **`openalex_tool_pkg/formatter.py`** — Transforms API responses to output JSON. Key logic: abstract reconstruction from OpenAlex's inverted index format, author filtering (1 author per work—searched author if applicable, else first author).
 - **`openalex_tool_pkg/config.py`** — Field definitions. `CORE_FIELDS` (7 default fields), `EXTENDED_FIELDS` (19 optional), `FIELD_ALIASES` (e.g., `date` → `publication_date`, `citations` → `cited_by_count`). Field include/exclude resolution.
-- **`openalex_tool_pkg/config_manager.py`** — Persistent user config at `~/.openalex-tool/config.json`. Currently stores email for polite pool API access.
+- **`openalex_tool_pkg/name_resolver.py`** — Tavily search integration for resolving abbreviated author names (first initials) to full names. Handles TSV author file parsing, abbreviation detection, and institutional context for better lookups.
+- **`openalex_tool_pkg/config_manager.py`** — Persistent user config at `~/.openalex-tool/config.json`. Stores email for polite pool API access and Tavily API key.
 
 ### Data Flow
 
-CLI args → validate (at least one search param required) → resolve author names to IDs via API (if `--author-file`) → build query filters → paginated API search (with batching/dedup) → format each work → write JSON with metadata.
+CLI args → validate (at least one search param required) → parse author file (TSV or plain text) → resolve abbreviated names via Tavily (if enabled) → lookup author IDs via OpenAlex API (with optional institution filter) → build query filters → paginated API search (with batching/dedup) → format each work → write JSON with metadata.
 
 ### Key Design Decisions
 
@@ -80,7 +81,7 @@ CLI args → validate (at least one search param required) → resolve author na
 
 ## Dependencies
 
-Single runtime dependency: `requests>=2.31,<3`. Dev dependency: `pytest>=7.0`. Python 3.8+.
+Single runtime dependency: `requests>=2.31,<3`. Dev dependency: `pytest>=7.0`. Optional dependency: `tavily-python>=0.3.0` (install via `pip install -e ".[tavily]"`). Python 3.8+.
 
 ## Contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,13 @@ openalex-tool/
 │   ├── config.py               # Field definitions and validation
 │   ├── config_manager.py       # Persistent user config (~/.openalex-tool/)
 │   ├── formatter.py            # API response → output JSON
+│   ├── name_resolver.py        # Tavily name resolution, TSV parsing
 │   └── openalex_client.py      # OpenAlex API client
 ├── tests/                      # pytest test suite
 │   ├── test_config.py
 │   ├── test_config_manager.py
 │   ├── test_formatter.py
+│   ├── test_name_resolver.py
 │   └── test_openalex_client.py
 ├── setup.py                    # Package configuration
 ├── requirements.txt            # Runtime dependencies

--- a/openalex_tool_pkg/config_manager.py
+++ b/openalex_tool_pkg/config_manager.py
@@ -72,6 +72,30 @@ def set_email(email: str) -> None:
     print(f"✓ Email configured: {email}")
 
 
+def get_tavily_api_key() -> Optional[str]:
+    """
+    Get the configured Tavily API key.
+
+    Returns:
+        Tavily API key from config, or None if not configured
+    """
+    config = load_config()
+    return config.get("tavily_api_key")
+
+
+def set_tavily_api_key(key: str) -> None:
+    """
+    Set the Tavily API key in configuration.
+
+    Args:
+        key: Tavily API key to save
+    """
+    config = load_config()
+    config["tavily_api_key"] = key
+    save_config(config)
+    print("Tavily API key configured.")
+
+
 def get_config_path() -> str:
     """Get the path to the config file for display purposes."""
     return str(CONFIG_FILE)

--- a/openalex_tool_pkg/name_resolver.py
+++ b/openalex_tool_pkg/name_resolver.py
@@ -1,0 +1,290 @@
+"""
+Name resolver module for handling abbreviated author names.
+
+Provides Tavily search integration for resolving first initials to full names,
+TSV author file parsing, and institutional context for better lookups.
+"""
+
+import os
+import re
+import sys
+import warnings
+from typing import Dict, List, Optional, Tuple
+
+
+def is_abbreviated_name(name: str) -> bool:
+    """
+    Detect if a name contains only first initials (no full first name).
+
+    Args:
+        name: Author name string (e.g., "E. Kelly" or "Eugene Kelly")
+
+    Returns:
+        True if all parts except the last are single characters (with optional period)
+    """
+    if not name or not name.strip():
+        return False
+
+    parts = name.strip().split()
+    if len(parts) < 2:
+        return False
+
+    # Check if all parts except the last are single-character initials
+    first_parts = parts[:-1]
+    return all(
+        len(p.rstrip(".")) == 1 and p.rstrip(".").isalpha()
+        for p in first_parts
+    )
+
+
+def detect_file_format(first_line: str) -> Optional[List[str]]:
+    """
+    Detect whether an author file is TSV format with headers or plain text.
+
+    Args:
+        first_line: The first line of the file
+
+    Returns:
+        List of header column names if TSV format, None if plain text
+    """
+    if "\t" not in first_line:
+        return None
+
+    columns = [col.strip() for col in first_line.split("\t")]
+    # Check for expected header names (case-insensitive)
+    lower_columns = [c.lower() for c in columns]
+    if "lastname" in lower_columns or "last_name" in lower_columns:
+        return columns
+
+    return None
+
+
+def parse_author_line(line: str, headers: Optional[List[str]] = None) -> Optional[Dict[str, str]]:
+    """
+    Parse a single line from an author file.
+
+    Args:
+        line: A single line from the author file
+        headers: Column headers if TSV format, None for plain text
+
+    Returns:
+        Dictionary with author info, or None if line is empty/invalid
+    """
+    line = line.strip()
+    if not line:
+        return None
+
+    if headers is None:
+        # Plain text mode: line is the full name
+        return {"name": line}
+
+    # TSV mode: split by tabs and map to headers
+    values = line.split("\t")
+    row = {}
+    header_lower_map = {}
+    for i, header in enumerate(headers):
+        lower = header.strip().lower()
+        header_lower_map[lower] = i
+
+    def get_val(key):
+        idx = header_lower_map.get(key)
+        if idx is not None and idx < len(values):
+            return values[idx].strip()
+        return ""
+
+    last_name = get_val("lastname") or get_val("last_name")
+    first_initial = get_val("firstinitial") or get_val("first_initial") or get_val("firstname") or get_val("first_name")
+    department = get_val("department")
+    college = get_val("college")
+
+    if not last_name:
+        return None
+
+    # Construct name from initial + last name
+    if first_initial:
+        initial = first_initial.rstrip(".")
+        name = f"{initial}. {last_name}"
+    else:
+        name = last_name
+
+    result = {"name": name, "last_name": last_name}
+    if first_initial:
+        result["first_initial"] = first_initial
+    if department:
+        result["department"] = department
+    if college:
+        result["college"] = college
+
+    return result
+
+
+def get_tavily_api_key(cli_key: Optional[str] = None) -> Optional[str]:
+    """
+    Get Tavily API key from CLI arg, environment variable, or config file.
+
+    Args:
+        cli_key: API key provided via CLI argument
+
+    Returns:
+        API key string, or None if not found
+    """
+    if cli_key:
+        return cli_key
+
+    env_key = os.environ.get("TAVILY_API_KEY")
+    if env_key:
+        return env_key
+
+    try:
+        from .config_manager import get_tavily_api_key as get_config_key
+        return get_config_key()
+    except Exception:
+        return None
+
+
+def extract_full_name_from_results(tavily_response: dict, last_name: str, institution: Optional[str] = None) -> Optional[str]:
+    """
+    Extract a full author name from Tavily search results.
+
+    Searches the response answer, result titles, and content for a full name
+    matching the given last name.
+
+    Args:
+        tavily_response: Response dict from TavilyClient.search()
+        last_name: The author's last name to match
+        institution: Optional institution name for domain preference
+
+    Returns:
+        Full name string if found, None otherwise
+    """
+    # Regex to find "FirstName [MiddleInitial] LastName"
+    pattern = re.compile(
+        r'\b([A-Z][a-z]+(?:\s+[A-Z]\.?\s*)?)\s+' + re.escape(last_name) + r'\b'
+    )
+
+    # 1. Check the answer field first (most reliable)
+    answer = tavily_response.get("answer", "") or ""
+    match = pattern.search(answer)
+    if match:
+        first_part = match.group(1).strip()
+        return f"{first_part} {last_name}"
+
+    # 2. Check results, preferring institutional domain matches
+    results = tavily_response.get("results", [])
+
+    # Separate institutional and non-institutional results
+    inst_results = []
+    other_results = []
+    inst_domain = None
+    if institution and "colorado state" in institution.lower():
+        inst_domain = "colostate.edu"
+
+    for r in results:
+        url = r.get("url", "")
+        if inst_domain and inst_domain in url:
+            inst_results.append(r)
+        else:
+            other_results.append(r)
+
+    # Search institutional results first
+    for r in inst_results + other_results:
+        for field in ["title", "content"]:
+            text = r.get(field, "") or ""
+            match = pattern.search(text)
+            if match:
+                first_part = match.group(1).strip()
+                return f"{first_part} {last_name}"
+
+    return None
+
+
+def resolve_abbreviated_name(
+    name: str,
+    institution: Optional[str] = None,
+    department: Optional[str] = None,
+    college: Optional[str] = None,
+    tavily_api_key: Optional[str] = None,
+) -> Tuple[str, bool]:
+    """
+    Resolve an abbreviated name to a full name using Tavily search.
+
+    If the name is not abbreviated, returns it unchanged. If Tavily is
+    unavailable or resolution fails, returns the original name.
+
+    Args:
+        name: Author name (e.g., "E. Kelly")
+        institution: Institution name for search context
+        department: Department name for search context
+        college: College name for search context
+        tavily_api_key: Tavily API key
+
+    Returns:
+        Tuple of (resolved_name, was_resolved)
+    """
+    if not is_abbreviated_name(name):
+        return (name, False)
+
+    # Check if tavily-python is installed
+    try:
+        from tavily import TavilyClient  # noqa: F401
+    except ImportError:
+        warnings.warn(
+            "tavily-python not installed. Install with: pip install tavily-python",
+            stacklevel=2,
+        )
+        return (name, False)
+
+    if not tavily_api_key:
+        warnings.warn(
+            "No Tavily API key configured. Set with --set-tavily-key or TAVILY_API_KEY env var.",
+            stacklevel=2,
+        )
+        return (name, False)
+
+    # Extract last name for matching
+    parts = name.strip().split()
+    last_name = parts[-1]
+
+    # Build search query with institutional context
+    query_parts = [name]
+    if college:
+        query_parts.append(college)
+    if department:
+        query_parts.append(department)
+    if institution:
+        query_parts.append(institution)
+    query_parts.append("professor")
+    query = " ".join(query_parts)
+
+    # Set up domain filter for known institutions
+    search_kwargs = {
+        "query": query,
+        "include_answer": "advanced",
+        "max_results": 5,
+    }
+    inst_domain = None
+    if institution and "colorado state" in institution.lower():
+        inst_domain = "colostate.edu"
+
+    try:
+        client = TavilyClient(api_key=tavily_api_key)
+
+        # Try with domain filter first, fall back to unrestricted
+        if inst_domain:
+            search_kwargs["include_domains"] = [inst_domain]
+        response = client.search(**search_kwargs)
+        full_name = extract_full_name_from_results(response, last_name, institution)
+
+        if not full_name and inst_domain:
+            # Retry without domain restriction
+            search_kwargs.pop("include_domains", None)
+            response = client.search(**search_kwargs)
+            full_name = extract_full_name_from_results(response, last_name, institution)
+    except Exception as e:
+        print(f"  Warning: Tavily search failed for '{name}': {e}", file=sys.stderr)
+        return (name, False)
+
+    if full_name:
+        return (full_name, True)
+
+    return (name, False)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "dev": ["pytest>=7.0"],
+        "tavily": ["tavily-python>=0.3.0"],
     },
     entry_points={
         "console_scripts": [

--- a/tests/test_name_resolver.py
+++ b/tests/test_name_resolver.py
@@ -1,0 +1,268 @@
+"""Tests for openalex_tool_pkg.name_resolver module."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from openalex_tool_pkg.name_resolver import (
+    is_abbreviated_name,
+    detect_file_format,
+    parse_author_line,
+    get_tavily_api_key,
+    extract_full_name_from_results,
+    resolve_abbreviated_name,
+)
+
+
+class TestIsAbbreviatedName:
+    def test_single_initial_with_period(self):
+        assert is_abbreviated_name("E. Kelly") is True
+
+    def test_single_initial_without_period(self):
+        assert is_abbreviated_name("E Kelly") is True
+
+    def test_full_name(self):
+        assert is_abbreviated_name("Eugene Kelly") is False
+
+    def test_multiple_initials(self):
+        assert is_abbreviated_name("J. R. Smith") is True
+
+    def test_empty_string(self):
+        assert is_abbreviated_name("") is False
+
+    def test_single_word(self):
+        assert is_abbreviated_name("Kelly") is False
+
+    def test_whitespace_only(self):
+        assert is_abbreviated_name("   ") is False
+
+    def test_full_first_with_middle_initial(self):
+        assert is_abbreviated_name("Eugene R. Kelly") is False
+
+    def test_initial_with_full_middle(self):
+        assert is_abbreviated_name("E. Robert Kelly") is False
+
+
+class TestDetectFileFormat:
+    def test_tsv_header_detected(self):
+        line = "College\tDepartment\tLastName\tFirstInitial\tRank"
+        result = detect_file_format(line)
+        assert result is not None
+        assert "College" in result
+        assert "LastName" in result
+
+    def test_plain_text_returns_none(self):
+        assert detect_file_format("Eugene Kelly") is None
+
+    def test_tab_without_expected_headers(self):
+        assert detect_file_format("foo\tbar\tbaz") is None
+
+    def test_underscore_variant(self):
+        line = "College\tDepartment\tLast_Name\tFirst_Name"
+        result = detect_file_format(line)
+        assert result is not None
+
+
+class TestParseAuthorLine:
+    def test_plain_text_line(self):
+        result = parse_author_line("Eugene Kelly")
+        assert result == {"name": "Eugene Kelly"}
+
+    def test_plain_text_empty_line(self):
+        assert parse_author_line("") is None
+        assert parse_author_line("   ") is None
+
+    def test_tsv_with_headers(self):
+        headers = ["College", "Department", "LastName", "FirstInitial", "Rank"]
+        line = "Natural Sciences\tChemistry\tBernstein\tB\tProfessor"
+        result = parse_author_line(line, headers)
+        assert result["name"] == "B. Bernstein"
+        assert result["last_name"] == "Bernstein"
+        assert result["first_initial"] == "B"
+        assert result["department"] == "Chemistry"
+        assert result["college"] == "Natural Sciences"
+
+    def test_tsv_missing_lastname(self):
+        headers = ["College", "Department", "LastName", "FirstInitial"]
+        line = "Natural Sciences\tChemistry\t\tB"
+        assert parse_author_line(line, headers) is None
+
+    def test_tsv_no_first_initial(self):
+        headers = ["College", "Department", "LastName", "FirstInitial"]
+        line = "Natural Sciences\tChemistry\tSmith\t"
+        result = parse_author_line(line, headers)
+        assert result["name"] == "Smith"
+
+
+class TestGetTavilyApiKey:
+    def test_cli_key_wins(self):
+        assert get_tavily_api_key("cli-key-123") == "cli-key-123"
+
+    def test_env_var_used(self):
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "env-key-456"}):
+            assert get_tavily_api_key(None) == "env-key-456"
+
+    @patch("openalex_tool_pkg.name_resolver.get_tavily_api_key.__module__", "openalex_tool_pkg.name_resolver")
+    def test_config_used(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove TAVILY_API_KEY from env if present
+            env = os.environ.copy()
+            env.pop("TAVILY_API_KEY", None)
+            with patch.dict(os.environ, env, clear=True):
+                with patch("openalex_tool_pkg.config_manager.get_tavily_api_key", return_value="config-key-789"):
+                    result = get_tavily_api_key(None)
+                    assert result == "config-key-789"
+
+    def test_none_when_nothing_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            env = os.environ.copy()
+            env.pop("TAVILY_API_KEY", None)
+            with patch.dict(os.environ, env, clear=True):
+                with patch("openalex_tool_pkg.config_manager.get_tavily_api_key", return_value=None):
+                    assert get_tavily_api_key(None) is None
+
+
+class TestExtractFullNameFromResults:
+    def test_extracts_from_answer(self):
+        response = {
+            "answer": "Professor Eugene Kelly is a faculty member at Colorado State University.",
+            "results": [],
+        }
+        result = extract_full_name_from_results(response, "Kelly")
+        assert result == "Eugene Kelly"
+
+    def test_extracts_from_result_content(self):
+        response = {
+            "answer": "",
+            "results": [
+                {
+                    "title": "Faculty Profile",
+                    "content": "Dr. Eugene Kelly specializes in philosophy.",
+                    "url": "https://colostate.edu/profile",
+                }
+            ],
+        }
+        result = extract_full_name_from_results(response, "Kelly")
+        assert result == "Eugene Kelly"
+
+    def test_prefers_institutional_domain(self):
+        response = {
+            "answer": "",
+            "results": [
+                {
+                    "title": "Michael Kelly - Other Univ",
+                    "content": "Michael Kelly is a professor.",
+                    "url": "https://other.edu/profile",
+                },
+                {
+                    "title": "Eugene Kelly - CSU",
+                    "content": "Eugene Kelly teaches philosophy.",
+                    "url": "https://colostate.edu/profile",
+                },
+            ],
+        }
+        result = extract_full_name_from_results(response, "Kelly", "Colorado State University")
+        assert result == "Eugene Kelly"
+
+    def test_returns_none_on_no_match(self):
+        response = {
+            "answer": "No relevant information found.",
+            "results": [],
+        }
+        assert extract_full_name_from_results(response, "Kelly") is None
+
+    def test_handles_missing_answer(self):
+        response = {"results": []}
+        assert extract_full_name_from_results(response, "Kelly") is None
+
+    def test_extracts_from_result_title(self):
+        response = {
+            "answer": "",
+            "results": [
+                {
+                    "title": "Eugene Kelly | Department of Philosophy",
+                    "content": "",
+                    "url": "https://colostate.edu",
+                }
+            ],
+        }
+        result = extract_full_name_from_results(response, "Kelly")
+        assert result == "Eugene Kelly"
+
+
+class TestResolveAbbreviatedName:
+    def test_non_abbreviated_passthrough(self):
+        name, resolved = resolve_abbreviated_name("Eugene Kelly")
+        assert name == "Eugene Kelly"
+        assert resolved is False
+
+    @patch.dict("sys.modules", {"tavily": None})
+    def test_no_tavily_installed(self):
+        # Simulate tavily not installed by making import fail
+        import importlib
+        with patch("builtins.__import__", side_effect=ImportError("No module named 'tavily'")):
+            with pytest.warns(match="tavily-python not installed"):
+                name, resolved = resolve_abbreviated_name(
+                    "E. Kelly", tavily_api_key="test-key"
+                )
+            assert name == "E. Kelly"
+            assert resolved is False
+
+    def test_no_api_key_warns(self):
+        with patch("openalex_tool_pkg.name_resolver.is_abbreviated_name", return_value=True):
+            # Mock tavily import to succeed
+            mock_tavily = MagicMock()
+            with patch.dict("sys.modules", {"tavily": mock_tavily}):
+                with pytest.warns(match="No Tavily API key"):
+                    name, resolved = resolve_abbreviated_name("E. Kelly")
+                assert name == "E. Kelly"
+                assert resolved is False
+
+    def test_successful_resolution(self):
+        mock_tavily_module = MagicMock()
+        mock_client = MagicMock()
+        mock_client.search.return_value = {
+            "answer": "Eugene Kelly is a professor at Colorado State University.",
+            "results": [],
+        }
+        mock_tavily_module.TavilyClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {"tavily": mock_tavily_module}):
+            name, resolved = resolve_abbreviated_name(
+                "E. Kelly",
+                institution="Colorado State University",
+                department="Philosophy",
+                tavily_api_key="test-key",
+            )
+        assert name == "Eugene Kelly"
+        assert resolved is True
+
+    def test_failed_resolution_returns_original(self):
+        mock_tavily_module = MagicMock()
+        mock_client = MagicMock()
+        mock_client.search.return_value = {
+            "answer": "No information found.",
+            "results": [],
+        }
+        mock_tavily_module.TavilyClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {"tavily": mock_tavily_module}):
+            name, resolved = resolve_abbreviated_name(
+                "E. Kelly",
+                tavily_api_key="test-key",
+            )
+        assert name == "E. Kelly"
+        assert resolved is False
+
+    def test_tavily_search_exception(self):
+        mock_tavily_module = MagicMock()
+        mock_client = MagicMock()
+        mock_client.search.side_effect = Exception("API error")
+        mock_tavily_module.TavilyClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {"tavily": mock_tavily_module}):
+            name, resolved = resolve_abbreviated_name(
+                "E. Kelly",
+                tavily_api_key="test-key",
+            )
+        assert name == "E. Kelly"
+        assert resolved is False


### PR DESCRIPTION
When author files contain only first initials (e.g., "E. Kelly"), OpenAlex often resolves to the wrong person. This adds Tavily search integration to resolve abbreviated names to full names using institutional context (college, department) before the OpenAlex lookup. Also adds institution-filtered author lookups via a new institution_id parameter on lookup_author_id().

New features:
- name_resolver.py module with TSV parsing and Tavily integration
- --no-tavily, --tavily-api-key, --set-tavily-key CLI flags
- TSV author file format auto-detection
- Institution-filtered OpenAlex author lookups when --csu-only is set
- Graceful degradation when Tavily is unavailable